### PR TITLE
bug: 무장애정보조회 API 사용시 WebClientResponse/RequestException 임시조치

### DIFF
--- a/src/main/java/com/narae/fliwith/service/openAPI/TourService.java
+++ b/src/main/java/com/narae/fliwith/service/openAPI/TourService.java
@@ -35,6 +35,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 @Service
@@ -74,7 +76,10 @@ public class TourService {
                 .bodyToMono(new ParameterizedTypeReference<DetailWithTourRes.Root>() {
                 })
                 .map(root -> root.getResponse().getBody().getItems().getItem().get(0))
-                .onErrorReturn(DecodingException.class, new DetailWithTourRes.Item());
+                .onErrorReturn(DecodingException.class, new DetailWithTourRes.Item())
+                .onErrorReturn(WebClientResponseException.class, new DetailWithTourRes.Item())
+                .onErrorReturn(WebClientRequestException.class, new DetailWithTourRes.Item());
+
 
     }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
bug/webclientResReq -> main

### 반영 사항
- 무장애정보조회 API 호출 시 호출 횟수 제한 Exception이 발생해도 서비스 단에서 빈 객체 리턴하도록 임시 조치
    - 다른 오픈 API는 호출되는데 무장애정보조회 API만 해당 문제 발생...😭 (원인 알아보기) 
